### PR TITLE
Upper/lower conversion for left-alignment

### DIFF
--- a/variant_manip.cpp
+++ b/variant_manip.cpp
@@ -325,10 +325,10 @@ int32_t VariantManip::classify_variant(const char* chrom, uint32_t pos1, char** 
             {
                 ++diff;
 
-                if ((ref[j]=='G' && alt[j]=='A') ||
-                    (ref[j]=='A' && alt[j]=='G') ||
-                    (ref[j]=='C' && alt[j]=='T') ||
-                    (ref[j]=='T' && alt[j]=='C'))
+                if ((::toupper(ref[j])=='G' && ::toupper(alt[j])=='A') ||
+                    (::toupper(ref[j])=='A' && ::toupper(alt[j])=='G') ||
+                    (::toupper(ref[j])=='C' && ::toupper(alt[j])=='T') ||
+                    (::toupper(ref[j])=='T' && ::toupper(alt[j])=='C'))
                 {
                     ++ts;
                 }
@@ -372,7 +372,7 @@ void VariantManip::left_trim(std::vector<std::string>& alleles, uint32_t& pos1, 
 
     for (uint32_t i=0; i<alleles.size(); ++i)
     {
-        if (alleles[i].size()==1 || alleles[i].at(0)!=alleles[0].at(0))
+        if (alleles[i].size()==1 || ::tolower(alleles[i].at(0)) != ::tolower(alleles[0].at(0)))
         {
             may_left_trim = false;
             break;
@@ -406,8 +406,8 @@ void VariantManip::left_align(std::vector<std::string>& alleles, uint32_t& pos1,
     {
         if (!alleles[i].empty())
         {
-            lastBase = (lastBase != ' ') ? lastBase : alleles[i].at(alleles[i].size()-1);
-            if (lastBase != alleles[i].at(alleles[i].size()-1))
+            lastBase = (lastBase != ' ') ? lastBase : ::tolower(alleles[i].at(alleles[i].size()-1));
+            if (lastBase != ::tolower(alleles[i].at(alleles[i].size()-1)))
             {
                 may_right_trim = false;
             }
@@ -430,6 +430,7 @@ void VariantManip::left_align(std::vector<std::string>& alleles, uint32_t& pos1,
 
         char *ref = faidx_fetch_seq(fai, chrom, pos1-1, pos1-1, &ref_len);
         base = std::string(ref);
+        std::transform(base.begin(), base.end(), base.begin(), ::tolower);
         free(ref);
 
         for (uint32_t i=0; i<alleles.size(); ++i)

--- a/variant_manip.h
+++ b/variant_manip.h
@@ -35,6 +35,7 @@
 #include <list>
 #include <string>
 #include <iostream>
+#include <algorithm>
 #include "htslib/faidx.h"
 #include "htslib/kstring.h"
 #include "htslib/vcf.h"


### PR DESCRIPTION
Left-alignment seems to not work if there are differences in upper/lower caps between the VCF and the reference. 

Here is an example:

```
##fileformat=VCFv4.1
##FILTER=<ID=PASS,Description="All filters passed">
##reference=hg19
##contig=<ID=chr22,length=51304566>
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##INFO=<ID=_id,Number=1,Type=String,Description="PG ID">
##INFO=<ID=OLD_VARIANT,Number=1,Type=String,Description="Original chr:pos:ref:alt encoding">
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  SAMPLE
chr22   41817310        .       a       aA      .       PASS    _id=41817311;OLD_VARIANT=chr22:41817311:A,AA    GT      1/0
```

The reference sequence is 

```
>chr22:41817306-41817312
CAAAAAT
```

... so the variant should move to 41817306 to be totally left aligned.

Here is a proposal for a fix (assuming that this isn't a desired feature). Other bits of the code may have similar behaviour.
