### PR TITLE
Avoid clearing ID/QUAL/FILTER/INFO fields when decomposing multi-alleleic

### DIFF
--- a/decompose.cpp
+++ b/decompose.cpp
@@ -246,7 +246,6 @@ class Igor : Program
 
                 for (size_t i=1; i<n_allele; ++i)
                 {
-                    bcf_clear(v);
                     bcf_set_rid(v, rid);
                     bcf_set_pos1(v, pos1);
                     new_alleles.l=0;


### PR DESCRIPTION
Adrian;
The latest fixes to decompose to pass along the FORMAT DP field (https://github.com/atks/vt/commit/e51d17eafb3d2629a3580d824193c160d4ca3177) cleared all of the other variant fields, losing information like IDs, filters and quals and causing downstream errors (chapmanb/bcbio-nextgen#744).
This avoids clearing these.

Here's a small test case that shows the problem.
```
##fileformat=VCFv4.1
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##INFO=<ID=GC,Number=1,Type=Integer,Description="GC content around the variant (see docs for window size details)">
##contig=<ID=1,length=249250621>
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B
1	1460793	rs123	CTT	CT,C	.	PASS	GC=40	GT	0|1	1|2
1	1460797	.	G	C,A	.	PASS	GC=41	GT	0|1	1|2
```
Thanks much.