### PR TITLE
Don't declare member function as inline. Fixes atks/vt#8.

### DIFF
--- a/pileup.cpp
+++ b/pileup.cpp
@@ -505,7 +505,7 @@ PileupPosition& Pileup::operator[] (const int32_t i)
 /**
  * Returns the difference between 2 buffer positions
  */
-inline uint32_t Pileup::diff(uint32_t i, uint32_t j)
+uint32_t Pileup::diff(uint32_t i, uint32_t j)
 {
     return (i>=j ? i-j : buffer_size-(j-i));
 };


### PR DESCRIPTION
This fixes my issue. It seems that `inline`, a linker directive, should only be used when you expect the function to appear in multiple places during compilation, which does not apply here. This should be a safe fix.