### PR TITLE
Adding option for alignment-based decompose_block.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ SOURCES = align\
 		motif_tree\
 		motif_map\
 		multi_partition\
+		needle\
 		ordered_bcf_overlap_matcher\
 		ordered_region_overlap_matcher\
 		partition\

--- a/needle.cpp
+++ b/needle.cpp
@@ -1,0 +1,186 @@
+/* The MIT License
+
+   Copyright (c) 2015 Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "needle.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+NeedlemanWunsch::NeedlemanWunsch(bool debug)
+{
+    lt = new LogTool();
+    this->debug = debug;
+}
+
+NeedlemanWunsch::NeedlemanWunsch(LogTool *lt, bool debug)
+{
+    this->lt = lt;
+    this->debug = debug;
+}
+
+void NeedlemanWunsch::align(const char* ref, const char* read)
+{
+    this->ref = ref;
+    this->read = read;
+    this->len_ref = strlen(ref);
+    this->len_read = strlen(read);
+
+    matrix.clear();
+    matrix.resize((len_ref + 1) * (len_read + 1), EMPTY);
+
+    // fill first column and row
+    scores.resize(len_read + 1);
+    for (unsigned i = 0; i <= len_ref; ++i)
+        matrix.at(i * (len_read + 1)) = CIGAR_D;
+    for (unsigned i = 0; i <= len_read; ++i)
+    {
+        matrix.at(i) = CIGAR_I;
+        scores.at(i) = i * params.score_gap;
+    }
+    matrix.at(0) = CIGAR_M;
+
+    // fill remainder of the matrix
+    int offset = 0;
+    int score_n = 0;
+    for (unsigned i = 1; i <= len_ref; ++i)
+    {
+        offset += len_read + 1;
+        score_n += params.score_gap;
+        int best_score = 0;
+        for (unsigned j = 1; j <= len_read; ++j)
+        {
+            int score_nw = scores.at(j - 1);
+            int score_w = scores.at(j);
+
+            int score_diag = score_nw;
+            Traceback best_dir;
+            if (ref[i - 1] == read[j - 1])
+            {
+                best_dir = CIGAR_M;
+                score_diag += params.score_match;
+            }
+            else
+            {
+                best_dir = CIGAR_X;
+                score_diag += params.score_mismatch;
+            }
+
+            best_score = score_diag;
+
+            if (score_w + params.score_gap > best_score)
+            {
+                best_score = score_w + params.score_gap;
+                best_dir = CIGAR_D;
+            }
+            else if (score_n + params.score_gap > best_score)
+            {
+                best_score = score_n + params.score_gap;
+                best_dir = CIGAR_I;
+            }
+
+            scores.at(j - 1) = score_n;
+            score_n = best_score;
+            matrix.at(offset + j) = best_dir;
+        }
+        scores.back() = best_score;
+    }
+
+}
+
+void NeedlemanWunsch::trace_path()
+{
+    int i = len_ref;
+    int j = len_read;
+    int k = (len_read + 1) * (len_ref + 1) - 1;
+
+    trace.clear();
+
+    while (i>0 || j>0)
+    {
+        trace.push_back(matrix.at(k));
+        switch (matrix.at(k))
+        {
+            case CIGAR_X:
+            case CIGAR_M:
+                --i;
+                --j;
+                k -= len_read + 2;
+                break;
+            case CIGAR_I:
+                --j;
+                --k;
+                break;
+            case CIGAR_D:
+                --i;
+                k -= len_read + 1;
+                break;
+        }
+    }
+
+    std::reverse(trace.begin(), trace.end());
+}
+
+void NeedlemanWunsch::print_alignment(std::string const & pad)
+{
+    // print reference
+    std::cerr << pad;
+    for (unsigned i = 0, j = 0; i < trace.size(); ++i)
+    {
+        if (trace.at(i) == CIGAR_X || trace[i] == CIGAR_M || trace.at(i) == CIGAR_D)
+            std::cerr << ref[j++];
+        else
+            std::cerr << "-";
+    }
+    std::cerr << "\n";
+
+    // print trace
+    std::cerr << pad;
+    for (unsigned i = 0, j = 0, k = 0; i < trace.size(); ++i)
+    {
+        if (trace[i] == CIGAR_X || trace[i] == CIGAR_M)
+            std::cerr << ((ref[j++] == read[k++]) ? '|' : ' ');
+        else if (trace[i] == CIGAR_D)
+        {
+            j++;
+            std::cerr << " ";
+        }
+        else  // trace[i] == CIGAR_I
+        {
+            k++;
+            std::cerr << " ";
+        }
+    }
+    std::cerr << "\n";
+
+    // print read
+    std::cerr << pad;
+    for (unsigned i = 0, j = 0; i < trace.size(); ++i)
+    {
+        if (trace[i] == CIGAR_X || trace[i] == CIGAR_M || trace[i] == CIGAR_I)
+            std::cerr << read[j++];
+        else
+            std::cerr << "-";
+    }
+    std::cerr << "\n";
+}

--- a/needle.h
+++ b/needle.h
@@ -1,0 +1,102 @@
+/* The MIT License
+
+   Copyright (c) 2015 Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+#ifndef NEEDLE_H
+#define NEEDLE_H
+
+#include <vector>
+
+#include "log_tool.h"
+
+class NWParameters
+{
+    public:
+
+    int score_match;
+    int score_mismatch;
+    int score_gap;
+
+    NWParameters() : score_match(0), score_mismatch(-1), score_gap(-1)
+    {}
+};
+
+class NeedlemanWunsch
+{
+    public:
+
+    // in CIGAR: "?", "D", "M", "X", "I"
+    enum Traceback { EMPTY, CIGAR_D, CIGAR_M, CIGAR_X, CIGAR_I };
+
+    bool debug;
+    const char* ref;
+    const char* read;
+
+    int len_ref;
+    int len_read;
+
+    std::vector<int> scores;
+    std::vector<Traceback> matrix;
+    std::vector<Traceback> trace;
+
+    LogTool *lt;
+
+    NWParameters params;
+
+    /**
+     * Constructor.
+     */
+    NeedlemanWunsch(bool debug=false);
+
+    /**
+     * Constructor.
+     */
+    NeedlemanWunsch(LogTool *lt, bool debug=false);
+
+    void set_read(const char * read) {
+        this->read = read;
+    }
+
+    /**
+     * Align and compute genotype likelihood.
+     */
+    void align(const char* ref, const char* read);
+
+    /**
+     * Trace path after alignment and write to trace.
+     */
+    void trace_path();
+
+    /**
+     * Prints an alignment.
+     */
+    void print_alignment()
+    {
+        print_alignment("");
+    }
+
+    /**
+     * Prints an alignment with padding.
+     */
+    void print_alignment(std::string const & pad);
+};
+
+#endif  // ifndef NEEDLE_H


### PR DESCRIPTION
The algorithm works as follows:

- compute pairwise edit distance alignment, using Needleman-Wunsch
  algorithm, the first bases are force-aligned
- go over the alignment from left to right and break apart the alignment
  as follows
- each match followed by one or more gaps and each mismatch starts a new
  chunk
- gaps are assigned to the chunk left of them
- matches that are not followed by any gap are removed

For example

    ref  CGTAACT--TCTAGT
    alt  C-TACCACTCGAAGG

will be split into the following alignment parts (shown separted by
space columns of width 3 below)

    ref CG   A   T--   T   C   T   T
    alt C-   C   ACT   C   G   A   G

This splitting is quite aggressive but needs to be done for aligners
such as Freebayes that tends to pull together SNVs with nearby indels
even if the indel has a very small support only.