### PR TITLE
Fixed a compilation issue on macOs High Sierra

### DIFF
--- a/bcf_synced_reader.h
+++ b/bcf_synced_reader.h
@@ -176,7 +176,7 @@ class BCFSyncedReader
     //empty records that can be reused
     std::list<bcf1_t *> pool;
     //contains the most recent position to process
-    std::priority_queue<bcfptr, std::vector<bcfptr *>, CompareBCFPtr> pq;
+    std::priority_queue<bcfptr *, std::vector<bcfptr *>, CompareBCFPtr> pq;
 
     //useful stuff
 


### PR DESCRIPTION
This commit fixes a compile issue on macOs High Sierra with Xcode 9.0.1 installed.

This was the error we got. 

`g++ -pipe -std=c++0x -O3 -I./lib -I. -I./lib/htslib -I./lib/Rmath -I./lib/pcre2 -D__STDC_LIMIT_MACROS -o bcf_synced_reader.o -c bcf_synced_reader.cpp
In file included from bcf_synced_reader.cpp:24:
In file included from ./bcf_synced_reader.h:27:
In file included from ./hts_utils.h:37:
In file included from ./utils.h:36:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/queue:405:5: error: static_assert failed ""
    static_assert((is_same<_Tp, value_type>::value), "" );
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./bcf_synced_reader.h:179:71: note: in instantiation of template class 'std::__1::priority_queue<bcfptr, std::__1::vector<bcfptr *,
      std::__1::allocator<bcfptr *> >, CompareBCFPtr>' requested here
    std::priority_queue<bcfptr, std::vector<bcfptr *>, CompareBCFPtr> pq;
                                                                      ^
1 error generated.
make: *** [bcf_synced_reader.o] Error 1
`

This minor change fixes the problem.