### PR TITLE
Add option to keep close MNVs in decompose_blocksub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ cleanvt :
 
 test : vt
 	test/test.sh
+	test/test_mnv.sh
 
 debug : vt
 	test/test.sh debug

--- a/decompose_blocksub.cpp
+++ b/decompose_blocksub.cpp
@@ -51,7 +51,7 @@ class Igor : Program
     bool aggressive_mode;
     bool keep_mnv;
     bool output_phased_genotypes;
-    int max_mnv_dist = 2;
+    int max_mnv_dist;
     std::string input_vcf_file;
     std::string output_vcf_file;
     std::vector<GenomeInterval> intervals;
@@ -98,6 +98,7 @@ class Igor : Program
             TCLAP::ValueArg<std::string> arg_intervals("i", "i", "intervals []", false, "", "str", cmd);
             TCLAP::ValueArg<std::string> arg_interval_list("I", "I", "file containing list of intervals []", false, "", "file", cmd);
             TCLAP::ValueArg<std::string> arg_output_vcf_file("o", "o", "output VCF file [-]", false, "-", "str", cmd);
+            TCLAP::ValueArg<int>  arg_max_mnv_dist("d", "d", "MNVs max distance (when -m option is used) [2]", false, 2, "int", cmd);
             TCLAP::SwitchArg arg_aggressive("a", "a", "enable aggressive/alignment mode [false]", cmd, false);
             TCLAP::SwitchArg arg_mnv("m", "m", "keep MNVs (multi-nucleotide variants) [false]", cmd, false);
             TCLAP::SwitchArg arg_output_phased_genotypes("p", "p", "Output phased genotypes and PS tags for decomposed variants [false]", cmd, false);
@@ -109,6 +110,7 @@ class Igor : Program
             output_vcf_file = arg_output_vcf_file.getValue();
             aggressive_mode = arg_aggressive.getValue();
             keep_mnv = arg_mnv.getValue();
+            max_mnv_dist = arg_max_mnv_dist.getValue();
             output_phased_genotypes = arg_output_phased_genotypes.getValue();
             parse_intervals(intervals, arg_interval_list.getValue(), arg_intervals.getValue());
         }
@@ -437,6 +439,7 @@ class Igor : Program
         print_int_op("         [i] intervals               ", intervals);
         print_boo_op("         [a] align/aggressive mode   ", aggressive_mode);
         print_boo_op("         [m] keep MNVs (Multi-Nucleotide Variants)   ", keep_mnv);
+        print_boo_op("         [d] MNVs max distance (when -m option is used)   ", max_mnv_dist);
         print_boo_op("         [p] output phased genotypes ", output_phased_genotypes);
         std::clog << "\n";
     }

--- a/test/decompose_blocksub/mnv/1bp_dist_mnv.vcf
+++ b/test/decompose_blocksub/mnv/1bp_dist_mnv.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.1
+##contig=<ID=1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	159030	.	TAA	GAT	0.04	.	.

--- a/test/decompose_blocksub/mnv/2bp_dist_mnv.vcf
+++ b/test/decompose_blocksub/mnv/2bp_dist_mnv.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.1
+##contig=<ID=1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	159030	.	TAAC	GAAT	0.04	.	.

--- a/test/decompose_blocksub/mnv/complex_mnv.vcf
+++ b/test/decompose_blocksub/mnv/complex_mnv.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.1
+##contig=<ID=1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	159030	.	TAACC	GAATG	0.04	.	.

--- a/test/decompose_blocksub/mnv/simple_mnv.vcf
+++ b/test/decompose_blocksub/mnv/simple_mnv.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.1
+##contig=<ID=1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	159030	.	TA	CG	0.04	.	.

--- a/test/ssshtest
+++ b/test/ssshtest
@@ -1,0 +1,532 @@
+#!/bin/bash
+
+############################################################
+#  Program: ssshtest
+#  Authors : Ryan M Layer ryan.layer@gmail.com
+#            Brent S Pedersen bpederse@gmail.com
+
+# (c) 2015 - Ryan Layer, Brent Pedersen
+############################################################
+
+PROGRAM_NAME=sshtest
+VERSION=0.1.5
+
+RED='\033[0;31m'
+BRED='\033[1;31m' # bold
+
+GREEN='\033[0;32m'
+BGREEN='\033[1;32m' # bold
+
+BLUE='\033[0;33m'
+BOLD='\033[0;1m'
+NC='\033[0m' # No Color
+
+PASS=" ${BGREEN}PASS${NC}"
+FAIL=" ${BRED}FAIL${NC}"
+
+COLS=`tput cols`
+
+STDOUT_FILE=${TMPDIR:-/tmp}/o.$$
+STDERR_FILE=${TMPDIR:-/tmp}/e.$$
+OUTVAL=
+ERRVAL=
+RETVAL=
+CMD=
+VERBOSE=
+
+TOTAL=0
+SUCCESSES=0
+FAILS=0
+
+FLAG=0
+
+STOP_ON_FAIL=0
+
+trap report EXIT
+
+TESTS_TO_RUN=($@)
+
+RUN_NAME=
+
+#{{{ Command line parsing
+usage()
+{
+    cat << EOF
+
+usage: $0 OPTIONS
+
+OPTIONS can be:
+    -h      Show this message
+    -v      Print success messages
+EOF
+}
+
+# Check options passed in.
+while getopts "h v" OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERBOSE=1
+            ;;
+        ?)
+            usage
+            exit
+            ;;
+    esac
+done
+#}}}
+
+#{{{ exit codes
+EX_OK=0
+
+#The command was used incorrectly, e.g., with the wrong number of arguments, a
+#bad flag, a bad syntax in a parameter, or whatever.
+EX_USAGE=64
+
+#The input data was incorrect in some way.  This should only be used for user's
+#data and not system files.
+EX_DATAERR=65
+
+#An input file (not a system file) did not exist or was not readable.  This
+#could also include errors like ``No message'' to a mailer (if it cared to
+#catch it).
+EX_NOINPUT=66
+
+#The user specified did not exist.  This might be used for mail addresses or
+#remote logins.
+EX_NOUSER=67
+
+#The host specified did not exist.  This is used in mail addresses or network
+#requests.
+EX_NOHOST=68
+
+#A service is unavailable.  This can occur if a support program or file does
+#not exist.  This can also be used as a catchall message when something you
+#wanted to do doesn't work, but you don't know why.
+EX_UNAVAILABLE=69
+
+#An internal software error has been detected.  This should be limited to
+#non-operating system related errors as possible.
+EX_SOFTWARE=70
+
+#An operating system error has been detected.  This is intended to be used for
+#such things as ``cannot fork'', ``cannot create pipe'', or the like.  It
+#includes things like getuid returning a user that does not exist in the passwd
+#file.
+EX_OSERR=71
+
+#Some system file (e.g., /etc/passwd, /var/run/utmp, etc.) does not exist,
+#cannot be opened, or has some sort of error (e.g., syntax error).
+EX_OSFILE=72
+
+#A (user specified) output file cannot be created.
+EX_CANTCREAT=73
+
+#An error occurred while doing I/O on some file.
+EX_IOERR=74
+
+#Temporary failure, indicating something that is not really an error.  In
+#sendmail, this means that a mailer (e.g.) could not create a connection, and
+#the request should be reattempted later.
+EX_TEMPFAIL=75
+
+#The remote system returned something that was ``not possible'' during a
+#protocol exchange.
+EX_PROTOCOL=76
+
+#You did not have sufficient permission to perform the operation.  This is not
+#intended for file system problems, which should use EX_NOINPUT or
+#EX_CANTCREAT, but rather for higher level permissions.
+EX_NOPERM=77
+
+#Something was found in an unconfigured or misconfigured state.
+EX_CONFIG=78
+#}}}
+
+#{{{ function report {
+function report {
+    rm -f $STDOUT_FILE $STDERR_FILE
+
+    echo -e "\n$PROGRAM_NAME v$VERSION\n"
+
+    if [ "$STOP_ON_FAIL" -ne "0" ]
+    then
+        if [ "$FAILS" -ne "0" ]
+        then
+            printf "${BOLD}TESTING STOPPED ON FIRST FAIL${NC}\n\n"
+        fi
+    fi
+
+    printf "${NC}%-10s${NC}Tests\n" $TOTAL
+
+    if [ "$FAILS" -ne "0" ]
+    then
+        printf "${BRED}%-10s${NC}${BOLD}Failures${NC}\n" $FAILS
+        printf "${BGREEN}%-10s${NC}Successes\n" $SUCCESSES
+    else
+        printf "${BRED}%-10s${NC}Failures\n" $FAILS
+        printf "${BGREEN}%-10s${NC}${BOLD}Successes${NC}\n" $SUCCESSES
+    fi
+
+    tear_down
+
+    exit $FAILS
+}
+#}}}
+
+#{{{ function run {
+function run {
+    RUN_NAME=$1
+    shift
+
+    FLAG=0
+    if [ "${#TESTS_TO_RUN[*]}" -eq 0 ]
+    then
+        FLAG=1
+	
+	else 
+	
+		for i in "${TESTS_TO_RUN[@]}"
+		do
+			if [ "$RUN_NAME" == "$i" ]
+			then
+				FLAG=1
+				break
+			fi
+		done
+    fi
+
+    if [ "$FLAG" -eq 0 ]
+    then
+        return
+    else
+        export $RUN_NAME=1
+    fi
+
+    CMD="$@"
+
+    START=$(date +%s);
+    O="$("$@" >$STDOUT_FILE 2>$STDERR_FILE)"
+    RETVAL=$?
+    END=$(date +%s);
+    TOTAL_TIME=$((END-START))
+
+    RUN_TIME="$TOTAL_TIME sec"
+
+
+    OUTVAL=`cat $STDOUT_FILE`
+    ERRVAL=`cat $STDERR_FILE`
+
+    #make it pretty
+    RUN_NAME=${BOLD}$RUN_NAME${NC}
+	ELINES=$(wc -l $STDERR_FILE | awk '{print $1 }' &)
+	OLINES=$(wc -l $STDOUT_FILE | awk '{print $1 }' &)
+	wait
+    echo -e "\n$RUN_NAME ran in $RUN_TIME with $ELINES/$OLINES lines to STDERR/OUT"
+}
+#}}}
+
+#{{{ function print_exit_code {
+function print_exit_code {
+    case $1 in
+        $EX_OK)
+            echo "EX_OK"
+            ;;
+        $EX_USAGE)
+            echo "EX_USAGE"
+            ;;
+        $EX_DATAERR)
+            echo "EX_DATAERR"
+            ;;
+        $EX_NOINPUT)
+            echo "EX_NOINPUT"
+            ;;
+        $EX_NOUSER)
+            echo "EX_NOUSER"
+            ;;
+        $EX_NOHOST)
+            echo "EX_NOHOST"
+            ;;
+        $EX_UNAVAILABLE)
+            echo "EX_UNAVAILABLE"
+            ;;
+        $EX_SOFTWARE)
+            echo "EX_SOFTWARE"
+            ;;
+        $EX_OSERR)
+            echo "EX_OSERR"
+            ;;
+        $EX_OSFILE)
+            echo "EX_OSFILE"
+            ;;
+        $EX_CANTCREAT)
+            echo "EX_CANTCREAT"
+            ;;
+        $EX_IOERR)
+            echo "EX_IOERR"
+            ;;
+        $EX_TEMPFAIL)
+            echo "EX_TEMPFAIL"
+            ;;
+        $EX_PROTOCOL)
+            echo "EX_PROTOCOL"
+            ;;
+        $EX_NOPERM)
+            echo "EX_NOPERM"
+            ;;
+        $EX_CONFIG)
+            echo "EX_CONFIG"
+            ;;
+        *)
+            echo "Unknown code: $1"
+    esac
+}
+#}}}
+
+#{{{function assert_exit_code {
+function assert_exit_code {
+    
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    E=$(print_exit_code $1)
+    O=$(print_exit_code $RETVAL)
+    if [ $RETVAL -ne $1 ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL EXIT CODE (LINE $LINE)"
+        echo -e "-->\texpected $E, observed $O"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS EXIT CODE (LINE $LINE)"
+        if [ $VERBOSE ] 
+        then
+            echo -e "-->\texpected $E, observed $O"
+        fi
+    fi
+}
+#}}}
+
+#{{{ function assert_no_stdout {
+function assert_no_stdout {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ -n "$OUTVAL" ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL NON-EMPTY STDOUT (LINE $LINE)"
+        echo -e "-->\t$OUTVAL"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS EMPTY STDOUT (LINE $LINE)"
+    fi
+}
+#}}}
+
+#{{{ function assert_no_stderr {
+function assert_no_stderr {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ -n "$ERRVAL" ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL NON-EMPTY STDERR(LINE $LINE)"
+        echo -e "-->\t$ERRVAL"
+        tail $STDERR_FILE 
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS EMPTY STDERR(LINE $LINE)"
+    fi
+}
+#}}}
+
+#{{{function assert_stderr {
+function assert_stderr {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ -z "$ERRVAL" ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL EMPTY STDERR(LINE $LINE)"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS EMPTY STDERR(LINE $LINE)"
+        if [ $VERBOSE ] 
+        then
+            echo -e "-->\t$ERRVAL"
+        fi
+    fi
+}
+#}}}
+
+#{{{function assert_stdout {
+function assert_stdout {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ -z "$OUTVAL" ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL EMPTY STDOUT (LINE $LINE)"
+        tail $STDERR_FILE 
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS NON-EMPTY STDOUT (LINE $LINE)"
+        if [ $VERBOSE ] 
+        then
+            echo -e "-->\t$ERRVAL"
+        fi
+    fi
+}
+#}}}
+
+#{{{function assert_in_stderr {
+function assert_in_stderr {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ -z "$ERRVAL" ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL EMPTY STDERR (LINE $LINE)"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        if [[ $ERRVAL == *"$1"* ]]
+        then
+            SUCCESSES=$((SUCCESSES + 1))
+            echo -e "$PASS STDERR CONTAINS \"$1\" (LINE $LINE)"
+            if [ $VERBOSE ] 
+            then
+                echo -e "-->\t$ERRVAL"
+            fi
+        else
+            FAILS=$((FAILS + 1))
+            echo -e "$FAIL STDERR DOES NOT CONTAIN \"$1\" (LINE $LINE)"
+            echo -e "-->\t$ERRVAL"
+            tail $STDERR_FILE
+            if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+        fi
+    fi
+}
+#}}}
+
+#{{{function assert_in_stdout {
+function assert_in_stdout {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ -z "$OUTVAL" ]
+    then
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL EMPTY STDOUT (LINE $LINE)"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    else
+        if [[ $OUTVAL == *"$1"* ]]
+        then
+            SUCCESSES=$((SUCCESSES + 1))
+            echo -e "$PASS STDOUT CONTAINS \"$1\" (LINE $LINE)"
+            if [ $VERBOSE ] 
+            then
+                echo -e "-->\t$OUTVAL"
+            fi
+        else
+            FAILS=$((FAILS + 1))
+            echo -e "$FAIL STDOUT DOES NOT CONTAIN \"$1\" (LINE $LINE)"
+            echo -e "-->\t$OUTVAL"
+            tail $STDERR_FILE
+            if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+        fi
+    fi
+}
+#}}}
+
+#{{{ function assert_equal {
+function assert_equal {
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ "$1" == "$2" ]
+    then
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS \"$1\" == \"$2\" (LINE $LINE)"
+    else
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL \"$1\" != \"$2\" (LINE $LINE)"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    fi
+}
+#}}}
+
+#{{{ function assert_true {
+function assert_true {
+
+    COMMAND=("$@")
+    RES=`${COMMAND[@]}`
+    echo $RES || "AAAAAAAAAAA"
+
+    if [ "$FLAG" -eq 0 ];then return; fi
+
+    LINE=$(caller | cut -d " " -f1)
+
+    TOTAL=$((TOTAL + 1))
+    if [ "${COMMAND[@]}" == true ]
+    then
+        SUCCESSES=$((SUCCESSES + 1))
+        echo -e "$PASS $* (LINE $LINE)"
+    else
+        FAILS=$((FAILS + 1))
+        echo -e "$FAIL $* (LINE $LINE)"
+        tail $STDERR_FILE
+        if [ $STOP_ON_FAIL -ne "0" ];then exit; fi
+    fi
+}
+#}}}
+
+#{{{function tear_down 
+function tear_down 
+{
+    :
+    #define this function in your test to clean things up in the end
+}
+#}}}

--- a/test/test_mnv.sh
+++ b/test/test_mnv.sh
@@ -14,11 +14,11 @@ run simple_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/simple_
 assert_exit_code 0
 assert_in_stdout "1	159030	.	TA	CG"
 
-run 1bp_dist_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/1bp_dist_mnv.vcf
+run one_bp_dist_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/1bp_dist_mnv.vcf
 assert_exit_code 0
 assert_in_stdout "1	159030	.	TAA	GAT"
 
-run 2bp_dist_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/2bp_dist_mnv.vcf
+run two_bp_dist_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/2bp_dist_mnv.vcf
 assert_exit_code 0
 assert_in_stdout "1	159030	.	T	G"
 assert_in_stdout "1	159033	.	C	T"

--- a/test/test_mnv.sh
+++ b/test/test_mnv.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+VT=${DIR}/../vt
+
+. ${DIR}/ssshtest
+
+run simple_mnv_mnv_mode_off ${VT} decompose_blocksub ${DIR}/decompose_blocksub/mnv/simple_mnv.vcf
+assert_exit_code 0
+assert_in_stdout "1	159030	.	T	C"
+assert_in_stdout "1	159031	.	A	G"
+
+run simple_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/simple_mnv.vcf
+assert_exit_code 0
+assert_in_stdout "1	159030	.	TA	CG"
+
+run 1bp_dist_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/1bp_dist_mnv.vcf
+assert_exit_code 0
+assert_in_stdout "1	159030	.	TAA	GAT"
+
+run 2bp_dist_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/2bp_dist_mnv.vcf
+assert_exit_code 0
+assert_in_stdout "1	159030	.	T	G"
+assert_in_stdout "1	159033	.	C	T"
+
+run complex_mnv ${VT} decompose_blocksub -m ${DIR}/decompose_blocksub/mnv/complex_mnv.vcf
+assert_exit_code 0
+assert_in_stdout "1	159030	.	T	G"
+assert_in_stdout "1	159033	.	CC	TG"


### PR DESCRIPTION
Dear VT developpers,

I have implemented a new option in the `decompose_blocksub` module in order to keep close MNVs (max 2bp away by default) together and not decompose them into their constituent SNPs. 

This is really important for MNVs that belong to the same codon as the predicted effect can be quite different depending if their interpreted together or independently (see recent bibliography on the matter bellow).

Let me know if the implementation met your acceptance criterion.

Jérôme.

**Limitations**
Their is currently two limitations with the implementation that I propose:

- `-m` option wont work for complex variants (`length(ref) != length(alt)`) that are decomposed when the `-a` option is used
- `-m` option wont work with `-p` option. It's just that I don't really get this part of the code and I dont want to mess it up!


**Biblio on MNVs**:

- Exome-wide assessment of the functional impact and pathogenicity of multi-nucleotide mutations https://www.biorxiv.org/content/10.1101/258723v2.full 
- Landscape of multi-nucleotide variants in 125,748 human exomes and 15,708 genomes https://www.biorxiv.org/content/10.1101/573378v2.full
