### PR TITLE
Fix for REF vs FASTA case mismatch issue #46

### DIFF
--- a/variant_manip.cpp
+++ b/variant_manip.cpp
@@ -77,9 +77,9 @@ int32_t VariantManip::is_not_ref_consistent(bcf_hdr_t *h, bcf1_t *v)
     int32_t is_not_consistent = 0;
     for (uint32_t i=0; i<ref_len; ++i)
     {
-        if (toupper(vcf_ref[i]) != ref[i])
+        if (toupper(vcf_ref[i]) != toupper(ref[i]))
         {
-            if (ref[i]=='N' || toupper(vcf_ref[i])=='N')
+            if (toupper(vcf_ref[i])=='N' || toupper(ref[i])=='N')
             {
                 is_not_consistent = 1;
             }


### PR DESCRIPTION
Mixed case FASTA and upper case REF still causes mismatch/skipping.

This was mentioned in issue #46 at the end (after closing), and @lbeltrame provided a simple diff to fix it.  Since it seems to have fallen off the radar, here is a new pull request with their fix.

BTW: Using the `-n` option is not a viable fix, since it skips and also produces lots of pointless warnings.